### PR TITLE
Fix wrong confidence values

### DIFF
--- a/nvinfer_custom_lpr_parser/nvinfer_custom_lpr_parser.cpp
+++ b/nvinfer_custom_lpr_parser/nvinfer_custom_lpr_parser.cpp
@@ -118,7 +118,7 @@ bool NvDsInferParseCustomNVPlate(std::vector<NvDsInferLayerInfo> const &outputLa
        // Do softmax
        if (do_softmax) {
            do_softmax = false;
-           bank_softmax_max[valid_bank_count] = outputConfBuffer[curr_data];
+           bank_softmax_max[valid_bank_count] = outputConfBuffer[seq_id];
            valid_bank_count++;
        }
     }


### PR DESCRIPTION
Confidence is currently transferred from TensorRT network to Deepstream in a wrong way, resulting in random values.

The LPR network has two output layers:

```
1   OUTPUT kINT32 tf_op_layer_ArgMax 24              
2   OUTPUT kFLOAT tf_op_layer_Max 24              
```

The first is a 24x1 vector that contains detected characters, the second is a 24x1 vector that contains the confidence of each detected character.

At the moment, confidence of each detected character is extracted by using the detected character as key to the confidence vector.

```c
int curr_data = outputStrBuffer[seq_id];
...
bank_softmax_max[valid_bank_count] = outputConfBuffer[curr_data];
```

i.e., if the 2nd element of the detection vector is character 'Z', that is the 34th character listed in the dict file, its confidence is assumed to be the 34th element of the confidence vector (that doesn't even exist), while it should be the one correspondent to the order in which the character was detected (in this case the 2nd element of the confidence vector).

This should be:

```c
int curr_data = outputStrBuffer[seq_id];
...
bank_softmax_max[valid_bank_count] = outputConfBuffer[seq_id];
```

This patch fixes the issue.